### PR TITLE
Add "discord" id to newsletter component

### DIFF
--- a/src/app/components/newsletter/Newsletter.js
+++ b/src/app/components/newsletter/Newsletter.js
@@ -35,7 +35,10 @@ function Newsletter(props) {
       className="jumbotron jumbotron-fluid newsletter"
       style={props.style}
     >
-      <div className="text-left newsletter-container">
+      <div 
+        id="discord"
+        className="text-left newsletter-container"
+      >
         <div className="newsletter-left">
           <h1>
             <b>Join our Discord and newsletter!</b>


### PR DESCRIPTION
Currently, we tell students to go to our website, scroll down to the form, and input their info in order to join the Discord.
It would be better if we had a link to just take users directly to the form.

By adding `id="discord"` to that div in the newsletter component, we can now simply send people the following url: https://hack.ics.uci.edu/#discord
This behaves the same way as https://hack.ics.uci.edu/#newsletter

Although it doesn't change the appearance or functionality of anything else on the site, I will concede that adding an id in like that might be slightly hacky/not best practice.