### PR TITLE
added hackuci event data to /api/fbgraph response

### DIFF
--- a/hackuci-data.json
+++ b/hackuci-data.json
@@ -1,0 +1,26 @@
+{
+    "events":{
+       "data":[
+          {
+             "description":"Headphones and Laptop? Check. Notes and Boba? Check. Lofi Hip Hop - beats to relax/study/hack to? Check.\n\nIt’s go time.\n\nHackUCI is a 40 hour hackathon spanning from January 29th to January 31st. We’ve held all of our past HackUCI’s at UCI, with last year’s numbers boasting 500+ attendees, 1600+ applicants, and 90+ projects submitted. However, taking current safety measures into account, HackUCI will be held online this year. And even though the place and feel of the event may be different, the core of HackUCI is still the same:\n\nCreate. Connect. Inspire.\n\nCreate what hasn’t been built yet, Connect with talented individuals online to work on something great, and Inspire those who seek to learn and be inspired by others. \n\nWe invite you to apply for HackUCI when applications open on December 27th, 2020.\n\nFor more information, check out: hackuci.com",
+             "end_time":"2021-01-31T11:00:00-0800",
+             "name":"HackUCI 2021",
+             "start_time":"2021-01-29T19:00:00-0800",
+             "cover":{
+                "offset_x":50,
+                "offset_y":50,
+                "source":"https://scontent-sjc3-1.xx.fbcdn.net/v/t1.0-9/s720x720/130769722_5033661633318495_8580698697053802588_o.jpg?_nc_cat=109&ccb=2&_nc_sid=b386c4&_nc_ohc=UZLENxivQrUAX-0I0iU&_nc_ht=scontent-sjc3-1.xx&tp=7&oh=d5c0e3383b6de36c1ffe5aff8f577d2d&oe=603191F5",
+                "id":"5033661626651829"
+             },
+             "id":"198317618578620"
+          }
+       ],
+       "paging":{
+          "cursors":{
+             "before":"QVFIUldMa0ZA3OGx1bmthS0gxQ0EwbjFPQXZAONm9iWU51bHNDaW5UeHY4LXpkYlZAwU25GakJvUmhkMElPaFl3OGVEdDFpUVNST1AwR1VWWE1wanJVNk9aM1pR",
+             "after":"QVFIUmJVcnNYemhzT0s4dDZAOQ1Eta3lhdUdtczBxcUtfdnJoMFpoaG11ZAnY1U01XM3Y1LUREQ3U5ZAjM1SkM3SHFZAVzlocmN6SWEtc0JiSGxBVlJOazhDWjlB"
+          }
+       }
+    },
+    "id":"740322575985777"
+ }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const logger = require("express-logger");
 const mongoose = require("mongoose");
 const path = require("path");
 require("dotenv").config();
+const hackuciData = require("./hackuci-data.json")
 
 const { DiscordSignup, DiscordInvite } = require("./models.js");
 const jsonParser = bodyParser.json();
@@ -41,6 +42,9 @@ app.get("/api/fbgraph", function (req, res) {
       },
     })
     .then((response) => {
+      var apiData = response.data.events.data;
+      var combinedData = hackuciData.events.data.concat(apiData);
+      response.data.events.data = combinedData;
       res.json(response.data);
     })
     .catch(function (err) {


### PR DESCRIPTION
- /api/fbgraph now returns data from both Hack at UCI page and hardcoded data from HackUCI page in the file `hackuci-data.json`
- this should be reflected on the http://localhost:3000/events page
