### PR TITLE
fixed hackuci event image URL

### DIFF
--- a/hackuci-data.json
+++ b/hackuci-data.json
@@ -9,7 +9,7 @@
              "cover":{
                 "offset_x":50,
                 "offset_y":50,
-                "source":"https://scontent-sjc3-1.xx.fbcdn.net/v/t1.0-9/s720x720/130769722_5033661633318495_8580698697053802588_o.jpg?_nc_cat=109&ccb=2&_nc_sid=b386c4&_nc_ohc=UZLENxivQrUAX-0I0iU&_nc_ht=scontent-sjc3-1.xx&tp=7&oh=d5c0e3383b6de36c1ffe5aff8f577d2d&oe=603191F5",
+                "source":"https://scontent-sjc3-1.xx.fbcdn.net/v/t1.0-9/130769722_5033661633318495_8580698697053802588_o.jpg?_nc_cat=109&ccb=3&_nc_sid=340051&_nc_ohc=L0910GAzBk0AX_KkyIp&_nc_ht=scontent-sjc3-1.xx&oh=d1c50d9f278a25aa840b5224b0501e76&oe=60596020",
                 "id":"5033661626651829"
              },
              "id":"198317618578620"
@@ -20,7 +20,7 @@
              "before":"QVFIUldMa0ZA3OGx1bmthS0gxQ0EwbjFPQXZAONm9iWU51bHNDaW5UeHY4LXpkYlZAwU25GakJvUmhkMElPaFl3OGVEdDFpUVNST1AwR1VWWE1wanJVNk9aM1pR",
              "after":"QVFIUmJVcnNYemhzT0s4dDZAOQ1Eta3lhdUdtczBxcUtfdnJoMFpoaG11ZAnY1U01XM3Y1LUREQ3U5ZAjM1SkM3SHFZAVzlocmN6SWEtc0JiSGxBVlJOazhDWjlB"
           }
-       }
+       }             
     },
     "id":"740322575985777"
  }


### PR DESCRIPTION
- image for hackuci event is now a properly updated image URL
- this might only be a temporary fix because the old URL expired so this one might too, hopefully when we revamp how we pull data from multiple FB pages we can find a fix 