### PR TITLE
recruitment info session properly shows up as an upcoming event

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,9 +42,9 @@ app.get("/api/fbgraph", function (req, res) {
       },
     })
     .then((response) => {
-      var apiData = response.data.events.data;
-      var combinedData = hackuciData.events.data.concat(apiData);
-      response.data.events.data = combinedData;
+      //var apiData = response.data.events.data;
+      //var combinedData = hackuciData.events.data.concat(apiData);
+      //response.data.events.data = combinedData;
       res.json(response.data);
     })
     .catch(function (err) {


### PR DESCRIPTION
- the recruitment info session shows up as uncoming
- essentially I had to remove the change that let me manually add hackuci because its from a different fb page
- going to try to find a better solution to pull event data from multiple pages