### PR TITLE
Events page pulls from both Hack facebook pages

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,9 +42,6 @@ app.get("/api/fbgraph", function (req, res) {
       },
     })
     .then((response) => {
-      //var apiData = response.data.events.data;
-      //var combinedData = hackuciData.events.data.concat(apiData);
-      //response.data.events.data = combinedData;
       axios
       .get("https://graph.facebook.com/v7.0/me", {
         params: {


### PR DESCRIPTION
- added live event pulling from both [Hack at UCI](https://www.facebook.com/UCI.Hack/?eid=ARBH6QjtwS1Y1uLUeqbdEuXwKiuxupaZfSFhSZ3p8F2hmudAvd_-lvzL_AnhTDgxiCg6VXLODj6Smdcx) and [HackUCI](https://www.facebook.com/hackUCIrvine/?eid=ARAHTJpQgzFa7_yKoElnL3ApCwuDk0Ijq1-JKez4qgn_HmS2trzMGwxKB7bRcFNPuoMXZ4QRTVzNy1tX) facebook pages

- still need to add the environment variable FB_PAGE_TOKEN_HACKUCI to the production build for it to work
- last thing I'm worried about is that although I got these tokens to be "long-lasting", as in they never expire, the token details tool is telling me that data access expires in 3 months for all tokens even if I generate fresh ones (See image below) so we might have to solve that

![image](https://user-images.githubusercontent.com/37749663/110747926-e55c4e80-81f3-11eb-9690-cdee8e1a8204.png)
