### PR TITLE
Remove unused import when removing link to intern applications

### DIFF
--- a/client/src/app/views/recruitment/Recruitment.js
+++ b/client/src/app/views/recruitment/Recruitment.js
@@ -1,5 +1,4 @@
 import { Header } from "app/containers";
-import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";


### PR DESCRIPTION
Not removing an unused import throws an error when building the client during deployment.