### PR TITLE
Remove organizer applications from recruitment page

### DIFF
--- a/client/src/app/views/recruitment/Recruitment.js
+++ b/client/src/app/views/recruitment/Recruitment.js
@@ -13,8 +13,6 @@ import lightBulb from "assets/icons/light_bulb.svg";
 import searchIcon from "assets/icons/search_icon.svg";
 import gears from "assets/icons/gears.svg";
 import "./Recruitment.scss";
-import Button from "react-bootstrap/Button";
-
 
 const COMMITTEES = {
 	Corporate: <Corporate />,
@@ -66,17 +64,8 @@ function Recruitment() {
 							</Tab>
 						))}
 					</Tabs>
-					<Button
-						href="https://airtable.com/appi73UpO0E7U0RwR/shrvkL0Up9bQVXz0l"
-						target="_blank"
-						rel="noreferrer noopener"
-						className="apply"
-					>
-						<strong>Interested? Apply Now!</strong>
-					</Button>
 				</Container>
 			</section>
-			
 		</div>
 	);
 }


### PR DESCRIPTION
When 2024 Spring new organizer applications close at 11:59 pm on April 19th, this PR will be merged into main to remove the application button from the recruitment page.