### PR TITLE
Remove 2024 Intern Applications

### DIFF
--- a/client/src/app/views/recruitment/Recruitment.js
+++ b/client/src/app/views/recruitment/Recruitment.js
@@ -65,14 +65,6 @@ function Recruitment() {
 							</Tab>
 						))}
 					</Tabs>
-					<Button
-						href="https://docs.google.com/forms/d/e/1FAIpQLSdZ47w2_ahyLPxHJp06P5HO7ZImIYTD2ScRy9FZgBCXNP95eQ/viewform"
-						target="_blank"
-						rel="noreferrer noopener"
-						className="apply"
-					>
-						<strong>Interested? Apply Now!</strong>
-					</Button>
 				</Container>
 			</section>
 		</div>


### PR DESCRIPTION
- Removes the button that links to the 2024 Intern Applications
- Merge this PR when apps close (November 8 at 11:59pm)